### PR TITLE
Configure order addresses url

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_klarna_payments.js
+++ b/app/assets/javascripts/spree/frontend/solidus_klarna_payments.js
@@ -24,6 +24,9 @@
         sessionUrl: Spree.urlForDomain(
           Spree.pathFor("solidus_klarna_payments/sessions")
         ),
+        orderAddressesUrl: Spree.urlForDomain(
+          Spree.pathFor("solidus_klarna_payments/sessions/order_addresses")
+        ),
         submitButton: $("form.edit_order :submit"),
       },
       options
@@ -105,9 +108,7 @@
       // First get the current, serialized order
       Spree.ajax({
         method: "GET",
-        url: Spree.urlForDomain(
-          Spree.pathFor("solidus_klarna_payments/sessions/order_addresses")
-        ),
+        url: settings.orderAddressesUrl,
         dataType: "json",
         data: { klarna_payment_method_id: settings.paymentId },
       }).done(function (result) {


### PR DESCRIPTION
Our solidus setup selects the current store by a store_id param in the request path. For examples our sessions path and order_addresses path look like:

```
/:store_id/solidus_klarna_payments/sesssions
/:store_id/solidus_klarna_payments/ /sessions/order_addresses
```

Before this change, we could already customize the session path. This change also allows to customize /sessions/order_addresses.