### PR TITLE
Add the BUY intent for one time payment sessions

### DIFF
--- a/app/presenters/solidus_klarna_payments/create_session_order_presenter.rb
+++ b/app/presenters/solidus_klarna_payments/create_session_order_presenter.rb
@@ -13,7 +13,7 @@ module SolidusKlarnaPayments
       return @serialized_order if defined? @serialized_order
 
       @serialized_order = order.to_klarna(klarna_payment_method.options[:country])
-      @serialized_order.intent = 'TOKENIZE' if tokenization_available?
+      @serialized_order.intent = intent
       @serialized_order.options = options
       @serialized_order.skip_personal_data = skip_personal_data
       @serialized_order.design = klarna_payment_method.options[:design]
@@ -33,6 +33,14 @@ module SolidusKlarnaPayments
 
     def tokenization_available?
       klarna_payment_method.preferred_tokenization && order.user.present?
+    end
+
+    def intent
+      if tokenization_available?
+        'TOKENIZE'
+      else
+        'BUY'
+      end
     end
 
     attr_reader :order, :klarna_payment_method, :store, :skip_personal_data

--- a/spec/presenters/solidus_klarna_payments/create_session_order_presenter_spec.rb
+++ b/spec/presenters/solidus_klarna_payments/create_session_order_presenter_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SolidusKlarnaPayments::CreateSessionOrderPresenter do
         let(:user) { nil }
 
         it 'returns the hash without the intent set' do
-          expect(serialized_order.to_hash).not_to include('intent')
+          expect(serialized_order.to_hash[:intent]).to eq('BUY')
         end
       end
 
@@ -47,10 +47,10 @@ RSpec.describe SolidusKlarnaPayments::CreateSessionOrderPresenter do
     end
 
     context 'when the payment method tokenize is set to false' do
-      let(:user) { nil }
+      let(:user) { create(:user) }
 
       it 'returns the hash without the intent set' do
-        expect(serialized_order.to_hash).not_to include('intent')
+        expect(serialized_order.to_hash[:intent]).to eq('BUY')
       end
     end
   end


### PR DESCRIPTION
This is needed to be compliant with the documentation when a customer creates a new session without the tokenization flow.