### PR TITLE
Extract customer token service

### DIFF
--- a/app/services/solidus_klarna_payments/create_customer_token_service.rb
+++ b/app/services/solidus_klarna_payments/create_customer_token_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module SolidusKlarnaPayments
+  class CreateCustomerTokenService < BaseService
+    def initialize(order:, authorization_token:, region:)
+      @order = order
+      @authorization_token = authorization_token
+      @region = region
+
+      super()
+    end
+
+    def call
+      @customer_token_response = Klarna
+                                 .client(:payment)
+                                 .customer_token(
+                                   authorization_token,
+                                   customer_token_params
+                                 )
+
+      @customer_token_response.token_id
+    rescue NoMethodError
+      nil
+    end
+
+    private
+
+    attr_reader :order, :region, :authorization_token
+
+    def customer_token_params
+      SolidusKlarnaPayments::CustomerTokenSerializer.new(
+        order: order,
+        description: 'Customer token',
+        region: region
+      ).to_hash
+    end
+  end
+end

--- a/app/subscribers/solidus_klarna_payments/klarna_subscriber.rb
+++ b/app/subscribers/solidus_klarna_payments/klarna_subscriber.rb
@@ -4,15 +4,15 @@ module SolidusKlarnaPayments
   module KlarnaSubscriber
     include ::Spree::Event::Subscriber
 
-    event_action :update_klarna_shipments, event_name: :order_recalulated
-    event_action :update_klarna_customer, event_name: :order_recalulated
+    event_action :update_klarna_shipments, event_name: :order_recalculated
+    event_action :update_klarna_customer, event_name: :order_recalculated
 
-    def update_klarna_shipments
+    def update_klarna_shipments(event)
       order = event.payload[:order]
       order.update_klarna_shipments
     end
 
-    def update_klarna_customer
+    def update_klarna_customer(event)
       order = event.payload[:order]
       order.update_klarna_customer
     end

--- a/spec/services/solidus_klarna_payments/create_customer_token_service_spec.rb
+++ b/spec/services/solidus_klarna_payments/create_customer_token_service_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe SolidusKlarnaPayments::CreateCustomerTokenService do
+  describe '#call' do
+    subject(:service) do
+      described_class
+        .call(
+          order: order,
+          authorization_token: authorization_token,
+          region: region
+        )
+    end
+
+    let(:order) { create(:order_with_line_items) }
+    let(:authorization_token) { 'AUTHORIZATION_TOKEN' }
+    let(:region) { 'us' }
+    let(:klarna_payment_client) { instance_double('Klarna::Payment') }
+    let(:customer_token_response) do
+      double('Klarna::Response', token_id: 'CUSTOMER_TOKEN') # rubocop:disable RSpec/VerifiedDoubles
+    end
+    let(:customer_token_serializer) { instance_double('SolidusKlarnaPayments::CustomerTokenSerializer') }
+    let(:klarna_customer_token_client) { instance_double('Klarna::CustomerToken') }
+
+    before do
+      allow(Klarna)
+        .to receive(:client)
+        .with(:payment)
+        .and_return(klarna_payment_client)
+
+      allow(klarna_payment_client)
+        .to receive(:customer_token)
+        .and_return(customer_token_response)
+
+      allow(klarna_customer_token_client)
+        .to receive(:place_order)
+
+      allow(SolidusKlarnaPayments::CustomerTokenSerializer)
+        .to receive(:new)
+        .and_return(customer_token_serializer)
+
+      allow(customer_token_serializer)
+        .to receive(:to_hash)
+        .and_return({ serialized_customer_token: 'yes' })
+    end
+
+    it 'calls the Klarna payment customer token method' do
+      service
+
+      expect(klarna_payment_client)
+        .to have_received(:customer_token)
+        .with(authorization_token, { serialized_customer_token: 'yes' })
+    end
+
+    it 'returns the token id' do
+      expect(service).to eq 'CUSTOMER_TOKEN'
+    end
+
+    it 'provides the right params to the CustomerTokenSerializer' do
+      service
+
+      expect(SolidusKlarnaPayments::CustomerTokenSerializer)
+        .to have_received(:new).with(
+          order: order,
+          description: 'Customer token',
+          region: region
+        )
+    end
+
+    context 'when customer token response is nil' do
+      let(:customer_token_response) { nil }
+
+      it 'returns nil without raising any exception' do
+        expect(service).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR extracts the creation of the customer token in dedicated service, so we can re-use it.