### PR TITLE
Refactor CreateCustomerTokenService to use email and address object instead of order object.

### DIFF
--- a/app/serializers/solidus_klarna_payments/customer_token_serializer.rb
+++ b/app/serializers/solidus_klarna_payments/customer_token_serializer.rb
@@ -2,22 +2,22 @@
 
 module SolidusKlarnaPayments
   class CustomerTokenSerializer
-    def initialize(order:, description:, region: :us)
-      @order = order
+    def initialize(email:, address:, currency:, description:, region: :us)
+      @email = email
+      @address = address
       @description = description
+      @currency = currency
       @region = region.downcase.to_sym
     end
 
     def to_hash
-      return {} unless order
-
       {
         locale: locale,
         intended_use: 'SUBSCRIPTION',
         description: description,
         purchase_country: purchase_country,
-        purchase_currency: order.currency,
-        billing_address: billing_address,
+        purchase_currency: currency,
+        billing_address: address,
       }
     end
 
@@ -38,14 +38,10 @@ module SolidusKlarnaPayments
     end
 
     def purchase_country
-      order.billing_address.try(:country).try(:iso) ||
-        order.shipping_address.try(:country).try(:iso) ||
-        region
+      address.try(:country).try(:iso) || region
     end
 
     def billing_address
-      address = order.billing_address.presence || order.shipping_address
-
       {
         email: order.email
       }.merge(
@@ -53,6 +49,6 @@ module SolidusKlarnaPayments
       )
     end
 
-    attr_reader :order, :description, :region
+    attr_reader :email, :address, :description, :currency, :region
   end
 end

--- a/app/services/solidus_klarna_payments/create_customer_token_service.rb
+++ b/app/services/solidus_klarna_payments/create_customer_token_service.rb
@@ -2,9 +2,11 @@
 
 module SolidusKlarnaPayments
   class CreateCustomerTokenService < BaseService
-    def initialize(order:, authorization_token:, region:)
-      @order = order
+    def initialize(email:, address:, authorization_token:, currency:, region:)
+      @email = email
+      @address = address
       @authorization_token = authorization_token
+      @currency = currency
       @region = region
 
       super()
@@ -25,12 +27,14 @@ module SolidusKlarnaPayments
 
     private
 
-    attr_reader :order, :region, :authorization_token
+    attr_reader :email, :address, :currency, :region, :authorization_token
 
     def customer_token_params
       SolidusKlarnaPayments::CustomerTokenSerializer.new(
-        order: order,
+        email: email,
+        address: address,
         description: 'Customer token',
+        currency: currency,
         region: region
       ).to_hash
     end

--- a/app/services/solidus_klarna_payments/place_order_with_customer_token_service.rb
+++ b/app/services/solidus_klarna_payments/place_order_with_customer_token_service.rb
@@ -41,7 +41,9 @@ module SolidusKlarnaPayments
       customer_token = SolidusKlarnaPayments::CreateCustomerTokenService
                        .call(
                          authorization_token: payment_source.authorization_token,
-                         order: order,
+                         email: order.email,
+                         address: order.billing_address || order.shipping_address,
+                         currency: order.currency,
                          region: region
                        )
 

--- a/lib/active_merchant/billing/klarna_gateway.rb
+++ b/lib/active_merchant/billing/klarna_gateway.rb
@@ -262,9 +262,12 @@ module ActiveMerchant
         return if payment.source.customer_token
         return unless payment.order.klarna_tokenizable?
 
+        profile_order = payment.order
         customer_token = SolidusKlarnaPayments::CreateCustomerTokenService.call(
-          order: payment.order,
+          email: profile_order.email,
+          address: profile_order.billing_address || profile_order.shipping_address,
           authorization_token: payment.source.authorization_token,
+          currency: payment.currency,
           region: payment.payment_method.preferred_country
         )
 

--- a/spec/lib/active_merchant/billing/klarna_gateway_spec.rb
+++ b/spec/lib/active_merchant/billing/klarna_gateway_spec.rb
@@ -148,6 +148,7 @@ describe ActiveMerchant::Billing::KlarnaGateway do
         fraud_status: 'fraud_status'
       )
     end
+    # rubocop:enable RSpec/VerifiedDoubles
 
     before do
       allow(SolidusKlarnaPayments::CreateCustomerTokenService).to receive(:call).and_return(customer_token)
@@ -157,8 +158,10 @@ describe ActiveMerchant::Billing::KlarnaGateway do
       create_profile
 
       expect(SolidusKlarnaPayments::CreateCustomerTokenService).to have_received(:call).with(
-        order: payment.order,
+        email: payment.order.email,
+        address: payment.order.billing_address || payment.order.shipping_address,
         authorization_token: authorization_token,
+        currency: payment.currency,
         region: payment.payment_method.preferred_country
       )
     end

--- a/spec/services/solidus_klarna_payments/create_customer_token_service_spec.rb
+++ b/spec/services/solidus_klarna_payments/create_customer_token_service_spec.rb
@@ -7,8 +7,10 @@ describe SolidusKlarnaPayments::CreateCustomerTokenService do
     subject(:service) do
       described_class
         .call(
-          order: order,
+          email: order.email,
+          address: order.billing_address,
           authorization_token: authorization_token,
+          currency: order.currency,
           region: region
         )
     end
@@ -62,8 +64,10 @@ describe SolidusKlarnaPayments::CreateCustomerTokenService do
 
       expect(SolidusKlarnaPayments::CustomerTokenSerializer)
         .to have_received(:new).with(
-          order: order,
+          email: order.email,
+          address: order.billing_address,
           description: 'Customer token',
+          currency: order.currency,
           region: region
         )
     end


### PR DESCRIPTION
This commit changes the required arguments for the `CreateCustomerTokenService` class.

The required arguments before were: `order`, `authorization_token`, `region`.
The required arguments now are: `email`, `address`, `authorization_token`, `currency` and `region`.

This change was made due to requirements of the `CreateCustomerTokenService` class which has now been isolated.
This service needs to be used in places where there may not be an order to setup a subscription. In those cases we need to still create the request body and generate the customer_token.

Hence, the changes in this commit to remove the dependency from the order and instead just use the required information to generate the customer_token from Klarna.