### PR TITLE
Move Controllers to Api Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $(container).klarnaAuthorize({
   paymentMethodWrapper: $(".form-payment-method-klarna_credit"),
   // The session URL of the store. The store needs to create a session from the server
   // side. This should not be changed.
-  sessionUrl: Spree.pathFor("/solidus_klarna_payments/session"),
+  sessionUrl: Spree.pathFor("/solidus_klarna_payments/api/session"),
 
   // The submit button that triggers the authorization. This button will be disabled while
   // the autorization is issued.

--- a/app/assets/javascripts/spree/frontend/solidus_klarna_payments.js
+++ b/app/assets/javascripts/spree/frontend/solidus_klarna_payments.js
@@ -22,7 +22,7 @@
         paymentMethodWrapper: $(".form-payment-method-klarna_credit"),
         preferredPaymentMethod: $(this).data("preferred-payment-method"),
         sessionUrl: Spree.urlForDomain(
-          Spree.pathFor("solidus_klarna_payments/sessions")
+          Spree.pathFor("solidus_klarna_payments/api/sessions")
         ),
         submitButton: $("form.edit_order :submit"),
       },
@@ -106,7 +106,7 @@
       Spree.ajax({
         method: "GET",
         url: Spree.urlForDomain(
-          Spree.pathFor("solidus_klarna_payments/sessions/order_addresses")
+          Spree.pathFor("solidus_klarna_payments/api/sessions/order_addresses")
         ),
         dataType: "json",
         data: { klarna_payment_method_id: settings.paymentId },

--- a/app/controllers/solidus_klarna_payments/api/base_controller.rb
+++ b/app/controllers/solidus_klarna_payments/api/base_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SolidusKlarnaPayments
+  module Api
+    class BaseController < ::Spree::StoreController
+      skip_before_action :verify_authenticity_token
+    end
+  end
+end

--- a/app/controllers/solidus_klarna_payments/api/callbacks_controller.rb
+++ b/app/controllers/solidus_klarna_payments/api/callbacks_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module SolidusKlarnaPayments
+  module Api
+    class CallbacksController < BaseController
+      def notification
+        payment_source = ::Spree::KlarnaCreditPayment.find_by!(order_id: params[:order_id])
+
+        case params[:event_type]
+        when 'FRAUD_RISK_ACCEPTED'
+          payment_source.accept!
+        when 'FRAUD_RISK_REJECTED', 'FRAUD_RISK_STOPPED'
+          payment_source.reject!
+        end
+
+        payment_source.payments.first.notify!(params)
+
+        # rubocop:disable Rails/SkipsModelValidations
+        payment_source.order.touch
+        # rubocop:enable Rails/SkipsModelValidations
+        render plain: 'ok'
+      end
+
+      def push
+        render plain: 'ok'
+      end
+    end
+  end
+end

--- a/app/controllers/solidus_klarna_payments/callbacks_controller.rb
+++ b/app/controllers/solidus_klarna_payments/callbacks_controller.rb
@@ -2,7 +2,10 @@
 
 module SolidusKlarnaPayments
   class CallbacksController < ::Spree::BaseController
+    include ::Spree::DeprecationHelper
+
     skip_before_action :verify_authenticity_token
+    before_action :deprecation_warning
 
     def notification
       payment_source = ::Spree::KlarnaCreditPayment.find_by!(order_id: params[:order_id])

--- a/app/controllers/solidus_klarna_payments/sessions_controller.rb
+++ b/app/controllers/solidus_klarna_payments/sessions_controller.rb
@@ -3,6 +3,9 @@
 module SolidusKlarnaPayments
   class SessionsController < ::Spree::BaseController
     include ::Spree::Core::ControllerHelpers::Order
+    include ::Spree::DeprecationHelper
+
+    before_action :deprecation_warning
 
     def create
       render json: {

--- a/app/helpers/spree/deprecation_helper.rb
+++ b/app/helpers/spree/deprecation_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Spree
+  module DeprecationHelper
+    def deprecation_warning
+      Spree::Deprecation.warn(
+        "\n----------------------------------------------------------------------\n" \
+        "#{self.class} has been deprecated and might be removed in future versions.\n" \
+        "Use #{self.class.to_s.gsub('::', '::Api::')} instead.\n" \
+        "----------------------------------------------------------------------\n"
+      )
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ SolidusKlarnaPayments::Engine.routes.draw do
   get '/sessions', to: '/solidus_klarna_payments/sessions#show'
   get '/sessions/order_addresses', to: '/solidus_klarna_payments/sessions#order_addresses'
 
+  post '/api/callbacks/notification', to: '/solidus_klarna_payments/api/callbacks#notification', as: :notification
+  post '/api/callbacks/push', to: '/solidus_klarna_payments/api/callbacks#push', as: :push
+
   post '/api/sessions', to: '/solidus_klarna_payments/api/sessions#create'
   get '/api/sessions', to: '/solidus_klarna_payments/api/sessions#show'
   get '/api/sessions/order_addresses', to: '/solidus_klarna_payments/api/sessions#order_addresses'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 SolidusKlarnaPayments::Engine.routes.draw do
-  post '/callbacks/notification', to: '/solidus_klarna_payments/callbacks#notification', as: :notification
-  post '/callbacks/push', to: '/solidus_klarna_payments/callbacks#push', as: :push
-
-  post '/sessions', to: '/solidus_klarna_payments/sessions#create'
-  get '/sessions', to: '/solidus_klarna_payments/sessions#show'
-  get '/sessions/order_addresses', to: '/solidus_klarna_payments/sessions#order_addresses'
-
   post '/api/callbacks/notification', to: '/solidus_klarna_payments/api/callbacks#notification', as: :notification
   post '/api/callbacks/push', to: '/solidus_klarna_payments/api/callbacks#push', as: :push
 
   post '/api/sessions', to: '/solidus_klarna_payments/api/sessions#create'
   get '/api/sessions', to: '/solidus_klarna_payments/api/sessions#show'
   get '/api/sessions/order_addresses', to: '/solidus_klarna_payments/api/sessions#order_addresses'
+
+  # deprecated routes
+  post '/callbacks/notification', to: '/solidus_klarna_payments/callbacks#notification'
+  post '/callbacks/push', to: '/solidus_klarna_payments/callbacks#push'
+  post '/sessions', to: '/solidus_klarna_payments/sessions#create'
+  get '/sessions', to: '/solidus_klarna_payments/sessions#show'
+  get '/sessions/order_addresses', to: '/solidus_klarna_payments/sessions#order_addresses'
 end

--- a/spec/requests/solidus_klarna_payments/api/callbacks_controller_spec.rb
+++ b/spec/requests/solidus_klarna_payments/api/callbacks_controller_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusKlarnaPayments::Api::CallbacksController do
+  describe '#notification' do
+    subject(:request) { post '/solidus_klarna_payments/api/callbacks/notification', params: params }
+
+    let!(:payment) { create(:klarna_payment, source: payment_source, order: order, payment_method: payment_source.payment_method) }
+
+    let(:order) { create(:order_with_line_items, state: 'complete') }
+    let(:payment_source) { create(:klarna_credit_payment, order_id: order_id, spree_order_id: order.id, fraud_status: 'PENDING') }
+
+    let(:order_id) { 'MY_ORDER_ID' }
+    let(:params) { { order_id: payment_source.order_id, event_type: event_type } }
+
+    context 'with FRAUD_RISK_ACCEPTED' do
+      let(:event_type) { 'FRAUD_RISK_ACCEPTED' }
+
+      it 'accepts the payment' do
+        expect {
+          request
+        }.to change { payment_source.reload.accepted? }.from(false).to(true)
+
+        expect(response.body).to eq('ok')
+      end
+
+      it 'logs the call' do
+        expect {
+          request
+        }.to change { payment.log_entries.count }.by(1)
+      end
+    end
+
+    context 'with FRAUD_RISK_REJECTED' do
+      let(:event_type) { 'FRAUD_RISK_REJECTED' }
+
+      it 'rejects the payment' do
+        expect {
+          request
+        }.to change { payment_source.reload.rejected? }.from(false).to(true)
+
+        expect(response.body).to eq('ok')
+      end
+
+      it 'logs the call' do
+        expect {
+          request
+        }.to change { payment.log_entries.count }.by(1)
+      end
+    end
+
+    context 'with FRAUD_RISK_UNKNOWN' do
+      let(:event_type) { 'FRAUD_RISK_UNKNOWN' }
+
+      it 'does not update the payment' do
+        expect {
+          request
+        }.not_to(change { payment_source.reload.fraud_status })
+
+        expect(response.body).to eq('ok')
+      end
+
+      it 'still logs the call' do
+        expect {
+          request
+        }.to change { payment.log_entries.count }.by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR comes as a response to a client getting CSRF errors coming from Klarna SessionsController. 
Since the controller is missing `skip_before_action :verify_authenticity_token` I've added and taken the opportunity to also refactor the controllers, moving them to Api namespace and making them inherit from BaseController