### PR TITLE
Add API Session controller

### DIFF
--- a/app/controllers/solidus_klarna_payments/api/sessions_controller.rb
+++ b/app/controllers/solidus_klarna_payments/api/sessions_controller.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module SolidusKlarnaPayments
+  module Api
+    class SessionsController < ::Spree::BaseController
+      include ::Spree::Core::ControllerHelpers::Order
+
+      def create
+        render json: {
+          token: SolidusKlarnaPayments::CreateOrUpdateKlarnaSessionService.call(
+            order: current_order,
+            klarna_payment_method: klarna_payment_method,
+            store: current_store
+          )
+        }
+      end
+
+      def show
+        render json: {
+          status: !current_order.klarna_session_expired?,
+          token: current_order.klarna_client_token,
+          data: klarna_order.to_hash,
+        }
+      end
+
+      def order_addresses
+        addresses = {
+          billing_address: SolidusKlarnaPayments::AddressSerializer.new(current_order.billing_address).to_hash,
+          shipping_address: SolidusKlarnaPayments::AddressSerializer.new(current_order.shipping_address).to_hash
+        }
+
+        addresses.update(addresses) do |_k, v|
+          { email: current_order.email }.merge(v)
+        end
+
+        render json: klarna_order.serialized_order.addresses
+      end
+
+      private
+
+      def klarna_order
+        SolidusKlarnaPayments::CreateSessionOrderPresenter.new(
+          order: current_order,
+          klarna_payment_method: klarna_payment_method,
+          store: current_store,
+          skip_personal_data: false
+        )
+      end
+
+      def klarna_payment_method
+        @klarna_payment_method ||= ::Spree::PaymentMethod.find_by(id: klarna_payment_method_id, type: 'Spree::PaymentMethod::KlarnaCredit')
+      end
+
+      def klarna_payment_method_id
+        params[:klarna_payment_method_id] || current_order.payments.where(source_type: 'Spree::KlarnaCreditPayment').last.payment_method_id
+      end
+    end
+  end
+end

--- a/app/controllers/solidus_klarna_payments/sessions_controller.rb
+++ b/app/controllers/solidus_klarna_payments/sessions_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module SolidusKlarnaPayments
-  class SessionsController < ::Spree::StoreController
+  class SessionsController < ::Spree::BaseController
+    include ::Spree::Core::ControllerHelpers::Order
+
     def create
       render json: {
         token: SolidusKlarnaPayments::CreateOrUpdateKlarnaSessionService.call(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,8 @@ SolidusKlarnaPayments::Engine.routes.draw do
   post '/sessions', to: '/solidus_klarna_payments/sessions#create'
   get '/sessions', to: '/solidus_klarna_payments/sessions#show'
   get '/sessions/order_addresses', to: '/solidus_klarna_payments/sessions#order_addresses'
+
+  post '/api/sessions', to: '/solidus_klarna_payments/api/sessions#create'
+  get '/api/sessions', to: '/solidus_klarna_payments/api/sessions#show'
+  get '/api/sessions/order_addresses', to: '/solidus_klarna_payments/api/sessions#order_addresses'
 end

--- a/spec/requests/solidus_klarna_payments/api/sessions_controller_spec.rb
+++ b/spec/requests/solidus_klarna_payments/api/sessions_controller_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusKlarnaPayments::Api::SessionsController do
+  describe '#create' do
+    subject(:make_request) { post '/solidus_klarna_payments/api/sessions', params: order_params }
+
+    let(:order_params) do
+      {
+        order_token: order.guest_token,
+        klarna_payment_method_id: payment_method.id,
+        format: :json
+      }
+    end
+    let!(:order) { create(:order_with_line_items, state: 'payment', user: user) }
+    let(:payment_method) { create(:klarna_credit_payment_method) }
+    let(:user) { create(:user) }
+
+    before do
+      login_as user
+
+      allow(SolidusKlarnaPayments::CreateOrUpdateKlarnaSessionService)
+        .to receive(:call)
+        .and_return('TOKEN')
+    end
+
+    it 'calls the create or update klarna session service' do
+      make_request
+
+      expect(SolidusKlarnaPayments::CreateOrUpdateKlarnaSessionService)
+        .to have_received(:call)
+        .with(
+          order: order,
+          klarna_payment_method: payment_method,
+          store: Spree::Store.default
+        )
+    end
+
+    it 'returns the session token' do
+      make_request
+
+      expect(JSON.parse(response.body)['token']).to eq('TOKEN')
+    end
+  end
+end


### PR DESCRIPTION
SolidusKlarnaPayments::SessionController inherits from
Spree::StoreController which is defined under solidus_frontend.
In order to avoid to include solidus_frontend, this commit adds another
session controller under api.