### PR TITLE
Fix issue on tax rate calculation

### DIFF
--- a/app/serializers/solidus_klarna_payments/line_item_serializer.rb
+++ b/app/serializers/solidus_klarna_payments/line_item_serializer.rb
@@ -37,7 +37,7 @@ module SolidusKlarnaPayments
 
     def line_item_tax_rate
       # TODO: should we just calculate this?
-      tax_rate = line_item.adjustments.tax.inject(0) { |total, tax| total + tax.source.amount }
+      tax_rate = line_item.adjustments.tax.inject(0) { |total, tax| total + tax.amount }
       (10_000 * tax_rate).to_i
     end
 


### PR DESCRIPTION
This commit aims to fix the issue in line_items_serializer when Spree::TaxRate is not present.
Currently the tax rate is calculated by using the value tax.source.amount from adjustments.
This causes an issue when Spree::TaxRate is not present in an app.

Here, a change has been made to calculate tax rate by using the value tax.amount of an adjustment instead to ensure that the extension works with apps where Spree::TaxRate is not present