### PR TITLE
Replace Spree::StoreController with BaseController

### DIFF
--- a/app/controllers/solidus_klarna_payments/callbacks_controller.rb
+++ b/app/controllers/solidus_klarna_payments/callbacks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SolidusKlarnaPayments
-  class CallbacksController < ::Spree::StoreController
+  class CallbacksController < ::Spree::BaseController
     skip_before_action :verify_authenticity_token
 
     def notification


### PR DESCRIPTION
SolidusKlarnaPayments::CallbackController inherits from
Spree::StoreController which is defined under solidus_frontend.
In order to avoid including solidus_frontend, this PR replaces StoreController with BaseController, so the PR is no more dependent on solidus_frontend