### PR TITLE
Change base controller for SolidusKlarnaPayments::Api::SessionsController

### DIFF
--- a/spec/requests/solidus_klarna_payments/api/sessions_controller_spec.rb
+++ b/spec/requests/solidus_klarna_payments/api/sessions_controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe SolidusKlarnaPayments::Api::SessionsController do
       {
         order_token: order.guest_token,
         klarna_payment_method_id: payment_method.id,
+        order_number: order.number,
         format: :json
       }
     end
@@ -18,8 +19,6 @@ RSpec.describe SolidusKlarnaPayments::Api::SessionsController do
     let(:user) { create(:user) }
 
     before do
-      login_as user
-
       allow(SolidusKlarnaPayments::CreateOrUpdateKlarnaSessionService)
         .to receive(:call)
         .and_return('TOKEN')


### PR DESCRIPTION
This commit changes the parent controller for `SolidusKlarnaPayments::Api::SessionsController` from `Spree::BaseCOntroller` to `Spree::Api::BaseController`.

This is done because methods in this controller will be requested by frontend frameworks and ajax calls and this change will allow this controller to use processes defined in Solidus for Api endpoints.