### PR TITLE
Fix Issue with Session Creation

### DIFF
--- a/app/services/solidus_klarna_payments/create_or_update_klarna_session_service.rb
+++ b/app/services/solidus_klarna_payments/create_or_update_klarna_session_service.rb
@@ -29,7 +29,7 @@ module SolidusKlarnaPayments
     def create_session
       klarna_payment_method
         .gateway
-        .create_session(order_params)
+        .create_session(order_params.except(:billing_address))
         .tap do |response|
           raise CreateOrUpdateKlarnaSessionError, response.inspect unless response.success?
 
@@ -45,7 +45,7 @@ module SolidusKlarnaPayments
         .gateway
         .update_session(
           order.klarna_session_id,
-          order_params
+          order_params.except(:billing_address)
         )
         .tap do |response|
           raise CreateOrUpdateKlarnaSessionError, response.inspect unless response.success?


### PR DESCRIPTION
There is an issue with session creation for klarna which causes the customer token flow to fail.

If the `billing_address` key is sent to Klarna during the session create or session update API calls then this causes any subsequent call to create a customer token to fail and generate a `nil` value.

This PR fixes this behaviour by removing the `billing_address` key from the data sent to Klarna during the create and update session API calls