### PR TITLE
Fix Issue when placing order with Authorization Token

### DIFF
--- a/app/serializers/solidus_klarna_payments/order_serializer.rb
+++ b/app/serializers/solidus_klarna_payments/order_serializer.rb
@@ -43,7 +43,6 @@ module SolidusKlarnaPayments
         locale: strategy.locale(region),
         # amount with taxes and adjustments
         order_amount: order.display_total.cents,
-        billing_address: billing_address,
         shipping_address: shipping_address,
         order_lines: order_lines,
         merchant_reference1: order.number,

--- a/spec/serializers/solidus_klarna_payments/order_serializer_spec.rb
+++ b/spec/serializers/solidus_klarna_payments/order_serializer_spec.rb
@@ -78,6 +78,22 @@ describe SolidusKlarnaPayments::OrderSerializer do
         expect(serialized[:merchant_urls][:confirmation]).to eq("my_confirmation_url")
       end
     end
+
+    it 'has the correct keys' do
+      expect(serialized.keys).to eq(
+        [
+          :purchase_country,
+          :purchase_currency,
+          :locale,
+          :order_amount,
+          :shipping_address,
+          :order_lines,
+          :merchant_reference1,
+          :options,
+          :order_tax_amount
+        ]
+      )
+    end
   end
 
   context "in the UK with included tax" do
@@ -140,6 +156,21 @@ describe SolidusKlarnaPayments::OrderSerializer do
         expect(serialized).not_to include(:billing_address, :shipping_address)
       end
     end
+
+    it 'has the correct keys' do
+      expect(serialized.keys).to eq(
+        [
+          :purchase_country,
+          :purchase_currency,
+          :locale,
+          :order_amount,
+          :shipping_address,
+          :order_lines,
+          :merchant_reference1,
+          :options
+        ]
+      )
+    end
   end
 
   context "in Germany" do
@@ -151,6 +182,21 @@ describe SolidusKlarnaPayments::OrderSerializer do
 
     it "sets the locale" do
       expect(serialized[:locale]).to eq("de-DE")
+    end
+
+    it 'has the correct keys' do
+      expect(serialized.keys).to eq(
+        [
+          :purchase_country,
+          :purchase_currency,
+          :locale,
+          :order_amount,
+          :shipping_address,
+          :order_lines,
+          :merchant_reference1,
+          :options
+        ]
+      )
     end
 
     context "without personal data" do
@@ -171,6 +217,21 @@ describe SolidusKlarnaPayments::OrderSerializer do
     it "sets the locale" do
       expect(serialized[:locale]).to eq("de-AT")
     end
+
+    it 'has the correct keys' do
+      expect(serialized.keys).to eq(
+        [
+          :purchase_country,
+          :purchase_currency,
+          :locale,
+          :order_amount,
+          :shipping_address,
+          :order_lines,
+          :merchant_reference1,
+          :options
+        ]
+      )
+    end
   end
 
   context "in Sweden" do
@@ -179,6 +240,21 @@ describe SolidusKlarnaPayments::OrderSerializer do
 
     it "sets the locale" do
       expect(serialized[:locale]).to eq("sv-SE")
+    end
+
+    it 'has the correct keys' do
+      expect(serialized.keys).to eq(
+        [
+          :purchase_country,
+          :purchase_currency,
+          :locale,
+          :order_amount,
+          :shipping_address,
+          :order_lines,
+          :merchant_reference1,
+          :options
+        ]
+      )
     end
   end
 end


### PR DESCRIPTION
There was an issue which came about due to this [PR#46](https://github.com/solidusio-contrib/solidus_klarna_payments/pull/46) where session create API call was updated to get it to work for the customer token flow.

The issue was that the `billing_address` field was removed from the session create API call to allow it to work with the customer token flow but Klarna is very strict while checking for fields in the session create and place order API calls.
Since the `billing_address` field still existed in the order create API call, Klarna Order creation failed while using the authorization token to place an order.

This has now been fixed by removing the `billing_address` field from the Order create API call and making the fields sent to both API calls consistent.

Related Commit
[5f4d049](https://github.com/solidusio-contrib/solidus_klarna_payments/commit/5f4d049555e241a67dfcd0372bfacb788d881ac3)