### PR TITLE
Support refund when payment_profiles_supported?

### DIFF
--- a/lib/active_merchant/billing/klarna_gateway.rb
+++ b/lib/active_merchant/billing/klarna_gateway.rb
@@ -94,7 +94,15 @@ module ActiveMerchant
         end
       end
 
-      def refund(amount, order_id, options = {})
+      def refund(*args)
+        payment = args.last[:originator].try(:payment)
+
+        if payment.payment_method.payment_profiles_supported?
+          amount, _source, order_id, options = args
+        else
+          amount, order_id, options = args
+        end
+
         # Get the refunded line items for better customer communications
         line_items = []
         if options[:originator].present?


### PR DESCRIPTION
When payment_profile_supported? returns true solidus provides 4
parameters to the refund method.

ref https://github.com/solidusio/solidus/blob/master/core/app/models/spree/refund.rb#L59-L76