### PR TITLE
Fix callback controller

### DIFF
--- a/app/controllers/solidus_klarna_payments/api/base_controller.rb
+++ b/app/controllers/solidus_klarna_payments/api/base_controller.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module SolidusKlarnaPayments
-  module Api
-    class BaseController < ::Spree::StoreController
-      skip_before_action :verify_authenticity_token
-    end
-  end
-end

--- a/app/controllers/solidus_klarna_payments/api/callbacks_controller.rb
+++ b/app/controllers/solidus_klarna_payments/api/callbacks_controller.rb
@@ -2,9 +2,14 @@
 
 module SolidusKlarnaPayments
   module Api
-    class CallbacksController < BaseController
+    class CallbacksController < ::Spree::Api::BaseController
+      include ::Spree::Core::ControllerHelpers::Order
+
       def notification
-        payment_source = ::Spree::KlarnaCreditPayment.find_by!(order_id: params[:order_id])
+        payment_source = ::Spree::KlarnaCreditPayment.find_by!(
+          spree_order_id: @order.id,
+          order_id: params[:klarna_order_id]
+        )
 
         case params[:event_type]
         when 'FRAUD_RISK_ACCEPTED'

--- a/spec/requests/solidus_klarna_payments/api/callbacks_controller_spec.rb
+++ b/spec/requests/solidus_klarna_payments/api/callbacks_controller_spec.rb
@@ -9,10 +9,18 @@ RSpec.describe SolidusKlarnaPayments::Api::CallbacksController do
     let!(:payment) { create(:klarna_payment, source: payment_source, order: order, payment_method: payment_source.payment_method) }
 
     let(:order) { create(:order_with_line_items, state: 'complete') }
-    let(:payment_source) { create(:klarna_credit_payment, order_id: order_id, spree_order_id: order.id, fraud_status: 'PENDING') }
+    let(:payment_source) { create(:klarna_credit_payment, order_id: klarna_order_id, spree_order_id: order.id, fraud_status: 'PENDING') }
 
-    let(:order_id) { 'MY_ORDER_ID' }
-    let(:params) { { order_id: payment_source.order_id, event_type: event_type } }
+    let(:klarna_order_id) { 'MY_ORDER_ID' }
+    let(:params) do
+      {
+        order_token: order.guest_token,
+        order_number: order.number,
+        klarna_order_id: klarna_order_id,
+        event_type: event_type,
+        format: :json
+      }
+    end
 
     context 'with FRAUD_RISK_ACCEPTED' do
       let(:event_type) { 'FRAUD_RISK_ACCEPTED' }


### PR DESCRIPTION
API controllers shouldn't inherit from Spree::StoreController because
some store doesn't have the frontend.

Before the changes, one of our stores failed with `uninitialized constant Spree::StoreController` because Spree::StoreController is defined only under solidus_frontend.