### PR TITLE
Fix 422 error for Api::SessionsController

### DIFF
--- a/app/controllers/solidus_klarna_payments/sessions_controller.rb
+++ b/app/controllers/solidus_klarna_payments/sessions_controller.rb
@@ -5,6 +5,7 @@ module SolidusKlarnaPayments
     include ::Spree::Core::ControllerHelpers::Order
     include ::Spree::DeprecationHelper
 
+    skip_before_action :verify_authenticity_token
     before_action :deprecation_warning
 
     def create


### PR DESCRIPTION
Some clients still report a 422 CSRF token error from the Api::SessionsController. 
Adding the `skip_before_action :verify_authenticity_token` should hopefully fix it